### PR TITLE
Update update URL

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -227,7 +227,7 @@ void OverviewPage::updateWallet()
     QObject* button = QObject::sender();
     if (button == ui->buttonUpgrade)
     {
-      QUrl url("https://github.com/akshaynexus/QuantisNet-NewChain/releases");
+      QUrl url("https://github.com/QuantisDev/QuantisNet-Core/releases");
       QDesktopServices::openUrl(url);
     }
 }


### PR DESCRIPTION
DVM update URL was incorrect after mainnet launch on the new official QuantisDev github account~ may lead to some confusion, hopefully this change was done quick enough.